### PR TITLE
upgrade bourbon-neat to 1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-neat",
-  "version": "1.7.1-beta1",
+  "version": "1.7.2",
   "description": "node-sass wrapper for thoughtbot's bourbon neat library",
   "main": "index.js",
   "scripts": {
@@ -20,7 +20,7 @@
     "url": "https://github.com/lacroixdesign/node-neat/issues"
   },
   "dependencies": {
-    "bourbon-neat": "1.7.1",
+    "bourbon-neat": "1.7.2",
     "node-bourbon": "^4.2.1-beta1"
   },
   "devDependencies": {


### PR DESCRIPTION
could also update here bourbon's dependency to 4.2.2. (Even though latest stable, as of now is 4.2.3)