### PR TITLE
Updated bourbon-neat to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ neat.includePaths // Array of Neat paths
 Use either method above with the Sass config for your chosen tool (gulp.js, Grunt, etc.), then it's business as usual for Neat & Bourbon in your stylesheet:
 
 ```scss
-@import "bourbon";
 @import "neat";
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,19 +1,11 @@
-var path = require('path');
-var bourbon = require('node-bourbon');
-
-var neatEntryPoint = require.resolve('bourbon-neat');
-var neatDir = path.dirname(neatEntryPoint);
-
-function includePaths() {
-  return bourbon.with(neatDir);
-}
+var bourbonNeat = require('bourbon-neat')
 
 module.exports = {
 
-  includePaths: includePaths(),
+  includePaths: bourbonNeat.includePaths,
 
-  with: function() {
-    return [].concat.apply(includePaths(), arguments);
+  with: function () {
+    return [].concat.apply(bourbonNeat.includePaths, arguments)
   }
 
-};
+}

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-var bourbonNeat = require('bourbon-neat')
+var bourbonNeat = require('bourbon-neat');
 
 module.exports = {
 
   includePaths: bourbonNeat.includePaths,
 
   with: function () {
-    return [].concat.apply(bourbonNeat.includePaths, arguments)
+    return [].concat.apply(bourbonNeat.includePaths, arguments);
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/lacroixdesign/node-neat/issues"
   },
   "dependencies": {
-    "bourbon-neat": "1.7.2",
+    "bourbon-neat": "^2.0.0",
     "node-bourbon": "^4.2.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "url": "https://github.com/lacroixdesign/node-neat/issues"
   },
   "dependencies": {
-    "bourbon-neat": "^2.0.0",
-    "node-bourbon": "^4.2.3"
+    "bourbon-neat": "^2.0.0"
   },
   "devDependencies": {
     "chai": "^1.10.0",


### PR DESCRIPTION
This change updates bourbon-neat to 2.x. This should probably live on a separate branch as 2.x is generally incompatible with 1.7.x (as it does away with a number of mixins).